### PR TITLE
Cygwin filesize colors fix

### DIFF
--- a/ls++
+++ b/ls++
@@ -485,7 +485,7 @@ sub relative_time {
 
 sub _get_color_support {
   my $colors = 8;
-  if(!($ENV{DISPLAY})) {
+  if(!($ENV{DISPLAY}) and !($ENV{SSH_CLIENT})) {
     $colors = 16;
     return $colors;
   }


### PR DESCRIPTION
I noticed that ls++ works fine as long as it thinks the terminal is in 256 mode (which it is). Did a hack job of _get_color_support, it shouldn't break tty unless you're SSHing with it. Not a permanent solution, though.
