### PR TITLE
Fix for OSX using day-month locales.

### DIFF
--- a/ls++
+++ b/ls++
@@ -145,6 +145,12 @@ sub ls {
 
         $perm =~ s/(?:\+|\@)$//g; # MacOS 'special extended attributes'
 
+        # OSX will order the month/day using the locale of the OS. If the day
+        # is alphanumeric, switch month and day.
+        if ($day =~ /[a-zA-Z]+/) {
+          ($day, $month) = ($month, $day);
+        }
+
         # Mac OS date conversion
         ($hour, $minute, $second) = split(/:/, $time);
         %mon2num = qw(


### PR DESCRIPTION
If your locale is set to one that uses day-month ordering instead of month-day when formatting dates, `ls` will show dates in that format and ls++ will get very confused, and complain about "Jan is not in range 1..31" or some such. This is a hack (ugly, but it works) to remedy that -- it checks to see if the day contains letters in it, and if it does, it assumes it's switched around the day and the month. This is a fix for [Issue 14](https://github.com/trapd00r/ls--/issues/14).