### PR TITLE
Fix a bug on Mac OS X 10.8.1.

### DIFF
--- a/ls++
+++ b/ls++
@@ -136,7 +136,7 @@ sub ls {
       ($file) = $line =~ m/.* \d{6,}? (.+)/;
     }
     elsif( ($^O eq 'darwin') or ($^O =~ /.+bsd$/) ) {
-        ($perm, $hlink, $user, $group, $size, $month, $day, $time, $year) = split(/\s+/, $line);
+        ($perm, $hlink, $user, $group, $size, $day, $month, $time, $year) = split(/\s+/, $line);
         if( (!$day) ) {
           printf("%s", $line);
           next;


### PR DESCRIPTION
Hi,

On a recent Mac OS, `$month` and `$day` from `/bin/ls` appears to be in another order than specified in the code. This patch fixes it.
