### PR TITLE
Colorize file type (socket/block/char/pipe) & First match wins

### DIFF
--- a/ls++
+++ b/ls++
@@ -22,8 +22,9 @@ if(not _init_config()) {;
   die "No configuration file found\n";
 }
 
-our(@c, @d, %ls_colors, $symlink_delim, $symlink_color, $directory_color,
-    $block_color, $character_color, $pipe_color, $socket_color);
+our(@c, @d, %ls_colors, @ls_colors, $symlink_delim, $symlink_color,
+    $directory_color, $block_color, $character_color, $pipe_color,
+    $socket_color);
 
 my $colors = _get_color_support();
 
@@ -243,6 +244,8 @@ sub ls {
 sub add_ls_color {
   my $file = shift;
 
+  # This is to handle the legacy hash based patterns. However, they're
+  # deprecated because they offer no means for ordering.
   for my $pattern(keys(%ls_colors)) {
     my $no_ls_color_file = uncolor($file);
 
@@ -254,6 +257,22 @@ sub add_ls_color {
       $file = fg($ls_colors{$pattern}, $file);
       return $file;
     }
+  }
+
+  # Here's a new array based ls_colors which allows explicit ordering.
+  foreach my $tuple (@ls_colors) {
+      my $pattern = $tuple->[0];
+      my $color = $tuple->[1];
+      my $no_ls_color_file = uncolor($file);
+
+      if($no_ls_color_file =~ /$pattern/) {
+          if($color eq 'IGNORE') {
+              return undef;
+          }
+          $file = $no_ls_color_file;
+          $file = fg($color, $file);
+          return $file;
+      }
   }
   return $file;
 }

--- a/ls++.conf
+++ b/ls++.conf
@@ -107,10 +107,10 @@ elsif($colorscheme eq 'trapd00r') {
   $c[15] = 196; # Min
 }
 
-%ls_colors = (
-  'README$'        => $c[8],
-  'Makefile$'      => $c[15],
-  '(=:.+)?\..*rc'  => $c[3],
+@ls_colors = (
+  ['README$'        ,$c[8]],
+  ['Makefile$'      ,$c[15]],
+  ['(=:.+)?\..*rc'  ,$c[3]],
 );
 
 
@@ -150,9 +150,17 @@ Colorscheme to be used.
 
 =item %ls_colors
 
-A hash where its keys are patterns (possibly valid regular expressions) to be
-matched against the files. The values should be attributes or colors which will
-be added to the output.
+The has based ls_colors is now deprecated. Please see @ls_colors.
+
+=back
+
+=item @ls_colors
+
+A array where of two element array references the first element is a pattern
+(possibly valid regular expressions) to be matched against the files. The second
+should be attributes or colors which will be added to the output. The attributes
+or colors of the pattern that matches first will be applied, so the array should
+be ordered by highest to lowest priority.
 
 This does the same thing as LS_COLORS, except that you can match against the
 full filname, and not only the extension. Using LS_COLORS, you could never match


### PR DESCRIPTION
This is two new features.
1. Allow the user to colorize based on file type (different color for directories, sockets, character/block special devices, pipes, etc)
2. If there is more than one pattern that matches, the first match wins.
