### PR TITLE
Fixed a bug that prevented the display of filenames on OS/X

### DIFF
--- a/ls++
+++ b/ls++
@@ -284,8 +284,7 @@ sub perm_time_size_file {
 
 sub perm_owner_time_size_file {
   my ($perm, $user, $rel, $size, $file) = @_;
-  if(get_os() eq 'darwin') {
-    printf("%s%s%s%s%s%s%6s%s%s\n",
+    printf("%s%s%s%s%s%s%s%s%s%s\n",
       $d[0],
       $perm,
       $d[3],
@@ -297,21 +296,6 @@ sub perm_owner_time_size_file {
       $d[2],
       $file,
     );
-  } 
-  else {
-    printf("%s %s%s%s%s%s%s%s%s%s\n",
-      $d[0],
-      $perm,
-      $d[3],
-      $user,
-      $d[2],
-      $rel,
-      $d[2],
-      $size,
-      $d[2],
-      $file,
-    );
-  }
 }
 
 sub perm_size_file {


### PR DESCRIPTION
On OS/X, ls++ did not display file names when used with the --potsf flag to display the owner of files.
