### PR TITLE
fix Mac OS X: bad alignment / size unit

### DIFF
--- a/ls++
+++ b/ls++
@@ -489,7 +489,7 @@ sub relative_time {
 
 sub _get_color_support {
   my $colors = 8;
-  if(!($ENV{DISPLAY})) {
+  if(exists($ENV{DISPLAY}) && !($ENV{DISPLAY})) {
     $colors = 16;
     return $colors;
   }


### PR DESCRIPTION
#39

I've just installed ls-- on Mac OS 10.9.4 with defaut configuration (OSX & ls--). 
While I execute ls--, I see that: 

```
bash-3.2$ ls++
▕-rw-r--r--▏<  min │      24857B16B│MANIFEST
▕-rw-r--r--▏<  min │        1071.1107K16│MYMETA.json
▕-rw-r--r--▏<  min │     248601B16B│MYMETA.yml
▕-rw-r--r--▏<  min │         10727107K16│Makefile
▕-rw-r--r--▏<  min │        1072.1107K16│Makefile.PL
▕-rw-r--r--▏<  min │        1072.3107K16│README.md
▕drwxr-xr-x▏38 sec │     248272B16B│blib
▕-rwxr-xr-x▏<  min │         10714107K16│ls++
▕-rw-r--r--▏<  min │        1074.0107K16│ls++.conf
▕-rw-r--r--▏38 sec │       2480B16B│pm_to_blib
bash-3.2$ pwd
/Users/me/ls--
```

The file size seems strange. 
