### PR TITLE
Install default configuration in ${PREFIX}/etc

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -60,3 +60,19 @@ sub WriteMakefile1 {
     WriteMakefile(%params);
 }
 
+sub MY::postamble {
+q{
+all :: sysconfdir
+
+sysconfdir_scripts=ls++
+
+sysconfdir:
+	$(PERL) -pi -e "s|\"/etc/ls\+\+\.conf|\"$(PREFIX)/etc/ls++.conf|g" $(sysconfdir_scripts)
+
+install_vendor :: ls++.conf
+	[ ! -d $(PREFIX)/etc ] && mkdir -p $(PREFIX)/etc
+	[ ! -f $(PREFIX)/etc/ls++.conf ] && cp ls++.conf $(PREFIX)/etc/ls++.conf
+
+install :: install_vendor
+}
+}


### PR DESCRIPTION
This patch does two things:
1. It makes ls++ search ${PREFIX}/etc instead of /etc for installation in non-default localization.
2. It installs default configuration in ${PREFIX}/etc so ls++ is usable from the beginning.

As I am not a Perl hacker I understand there might be better ways to do this, so I am open to suggestions.