### PR TITLE
support standard DESTDIR for packaging into a subdirectory

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -70,8 +70,8 @@ sysconfdir:
 	$(PERL) -pi -e "s|\"/etc/ls\+\+\.conf|\"$(PREFIX)/etc/ls++.conf|g" $(sysconfdir_scripts)
 
 install_vendor :: ls++.conf
-	[ ! -d $(PREFIX)/etc ] && mkdir -p $(PREFIX)/etc
-	[ ! -f $(PREFIX)/etc/ls++.conf ] && cp ls++.conf $(PREFIX)/etc/ls++.conf
+	[ ! -d $(DESTDIR)/$(PREFIX)/etc ] && mkdir -p $(DESTDIR)/$(PREFIX)/etc
+	[ ! -f $(DESTDIR)/$(PREFIX)/etc/ls++.conf ] && cp ls++.conf $(DESTDIR)/$(PREFIX)/etc/ls++.conf
 
 install :: install_vendor
 }


### PR DESCRIPTION
This is required for creating a package for a distribution as they
distribute the files in a sourcedir to create the tarball.
However the DESTDIR should not influence the runtime itself, therefor
PREFIX is the only variable considered in the $(sysconfdir_scripts)