### PR TITLE
Special files fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Not known parameters will be passed through to **ls**, so to show hidden files,
     --tpf   time, permissions, file
     --tpsf  time, permissions, size, file (default)
     --ptsf  permissions, time, size, file
+    --potsf permissions, owners, time, size, file
 
 # INSTALLATION
 

--- a/ls++
+++ b/ls++
@@ -25,6 +25,7 @@ if(not _init_config()) {;
 our(@c, @d, %ls_colors, $symlink_delim, $symlink_color);
 
 my $colors = _get_color_support();
+my ($sizelen, $stringlen);
 
 $ENV{DEBUG} and print "$_ x\n" for @c;
 
@@ -118,7 +119,7 @@ ls();
 sub ls {
   my $view = shift // 'perm_size_file';
   my($perm, $hlink, $user, $group, $size, $seconds, $file, $rel, $major_num, $minor_num);
-  my($userpad, $grouppad, $sizelen);
+  my($userpad, $grouppad);
   my($second, $minute, $hour, $time, $month, $day, $year, %mon2num); #for Mac OS
   my $the_time=time();
 
@@ -128,7 +129,6 @@ sub ls {
   local $/=undef;
   foreach my $sub (split(/\n\n/, <$ls>)) {
   $sizelen = get_max_size_len($sub);
-  printf("maxsize=%s\n", $sizelen);
   my $special_file;
   foreach my $line (split(/^/, $sub . "\n")) {
     my $firstchar = substr($line,0,1);
@@ -148,17 +148,14 @@ sub ls {
         ($perm, $hlink, $user, $group, $size, $seconds, $file) = split(/\s+/, $line, 7)
           unless $line =~ /^\s/;
           chop($file);
-          ($userpad, $grouppad) = $line =~ m/\d+\s+\S+\s(\s*)\S+(\s*)\s.{$sizelen}\s/;
-        }
+      }
       else {
         ($perm, $hlink, $user, $group, $major_num, $minor_num, $seconds, $file) = split(/\s+|,\s*/, $line, 8)
           unless $line =~ /^\s/;
-          $size = $major_num . ",". $minor_num; #special file don't list their size as regular files
+          $size = $major_num . ",". $minor_num; #special files don't list their size like regular files do
           chop($file);
-          ($userpad, $grouppad) = $line =~ m/\d+\s+\S+\s(\s*)\S+(\s*)\s.{$sizelen}\s/;
-        #printf("%s,%s,%s;size:%s\n", $major_num, $minor_num, $seconds, $size);
-        }
-      printf("userpad, grouppad, line: |%s_%s_%s", $userpad, $grouppad, $line);
+      }
+    ($userpad, $grouppad) = $line =~ m/\d+\s+\S+\s(\s*)\S+(\s*)\s.{$sizelen}\s\d+\s+.*/;
     }
     elsif( ($^O eq 'darwin') or ($^O =~ /.+bsd$/) ) {
         ($perm, $hlink, $user, $group, $size, $month, $day, $time, $year, $file) = split(/\s+/, $line, 10);
@@ -188,9 +185,8 @@ sub ls {
         printf("\n%s:\n", fg($c[9], fg('bold', $1)));
       }
       elsif( $line =~ /^total (.*)/ ) {
-        #printf("%s %s\n", fg($c[1], 'total'), ($size = size($1)) =~ s/\s+//gr);
         (undef, $size) = split(/\s+/, $line);
-        printf("%s %s\n", fg($c[1], 'total'), size($size));
+        printf("%s %s\n", fg($c[1], 'total'), ($size = size($1)) =~ s/\s+//gr);
       }
       next;
     }
@@ -233,7 +229,7 @@ sub ls {
     # OK, probably GNU/Linux
     else {
       $size = size($size);
-      $size =~ s/^\s{3}(.+)/$1 /;
+      #$size =~ s/\s{3}(.+)/$1 /; # probably not useful anymore
     }
 
     my $user = owner($userpad . $user, $group . $grouppad);
@@ -264,20 +260,16 @@ sub ls {
 
 sub get_max_size_len {
   my($out) = @_;
-  my($perm, $hlink, $user, $group, $size, $size2, $max, $cur);
+  my($size, $max, $cur);
   $max = 0;
   foreach my $line (split(/^/, $out)) {
-    if ($line =~ /,/){ #special file
-        (undef, undef, undef, undef, $size, $size2) = split(/\s+/, $line);
-        $size = $size . $size2;
-    }
-    else
-    {
-        (undef, undef, undef, undef, $size) = split(/\s+/, $line);
-    }
+    (undef, undef, undef, undef, $size) = split(/\s+/, $line);
     $cur = length($size);
+    #special files show between 4 and 7 characters + 1 space: 255, 255
+    if ($line =~ /\d+,\s+\d+/){
+        $cur += 4;
+    }
     $max = ($max, $cur)[$max < $cur];
-    printf("size, cur, max: %s_%s_%s\n", $size, $cur, $max);
   }
   return $max;
 }
@@ -382,7 +374,7 @@ sub perm_size_file {
     printf("%s%s%s%s%s%s%s\n", $d[0], $perm, $d[3], $size, $d[2], $file);
   }
   else {
-    printf("%s%s%s%19s%s%s\n", $d[0], $perm, $d[3], $size, $d[2], $file);
+    printf("%s%s%s%*s%s%s\n", $d[0], $perm, $d[3], $stringlen, $size, $d[2], $file);
   }
 }
 
@@ -391,6 +383,9 @@ sub perm_size_file {
 
 sub perm {
   my ($perm) = @_;
+  if (substr($perm,-1,1) ne "+"){
+    $perm .= " "; # adding an extra space to align with occasional +
+  }
 
   $perm =~ s/-/$d[1]/g;
   $perm =~ s/(r)/fg($c[2], $1)/eg;
@@ -417,33 +412,44 @@ sub owner {
 
 sub size {
   my ($size) = @_;
-  if ($size =~ /,/){
-        return $size;
-    }
+  if ($size =~ /\d+,\s*\d+/){ # not size but major/minor values for special files
+    $size = sprintf("%*s", $sizelen, $size);
+    return $size;
+  }
   #FIXME
   if($colors > 16) {
     #$size =~ s/(\S+)(K)/$c[2]$1\e[0m$c[4]$2\e[0m/gi;# and print "AA\n";
+    if($sizelen < 4){ # constraining size length between 4 and 8 characters max
+        $stringlen = 4;
+    }
+    elsif($sizelen >= 8){
+        $stringlen = 7;
+    }
+    else
+    {
+        $stringlen = $sizelen;
+    }
     if($size =~ m/^(\S+)(K)/) {
       $size = sprintf("%27s",
-        fg($c[7], sprintf("%4g", $1))
+        fg($c[7], sprintf("%*g", $stringlen, $1))
           . fg($c[2], fg('bold', $2))
         );
     }
     elsif($size =~ m/^(\S+)(M)/) {
       $size = sprintf("%29s",
-        fg($c[7], sprintf("%4g", $1))
+        fg($c[7], sprintf("%*g", $stringlen, $1))
           . fg($c[4], fg('bold', $2))
         );
     }
     elsif($size =~ m/^(\S+)(G)/) {
       $size = sprintf("%27s",
-        fg($c[7], sprintf("%4g", $1))
+        fg($c[7], sprintf("%*g", $stringlen, $1))
           . fg($c[3], fg('bold', $2))
         );
     }
     elsif($size =~ m/^(\d+)/) {
       $size = sprintf("%27s",
-        fg($c[7], sprintf("%4d", $1))
+        fg($c[7], sprintf("%*d", $stringlen, $1))
           . fg($c[14], fg('bold', 'B'))
         );
     }

--- a/ls++
+++ b/ls++
@@ -129,7 +129,6 @@ sub ls {
   local $/=undef;
   foreach my $sub (split(/\n\n/, <$ls>)) {
   ($sizelen, $permlen) = get_max_col_len($sub);
-  printf("sizelen, perm_len: %s,%s\n", $sizelen, $permlen);
   my $special_file;
   foreach my $line (split(/^/, $sub . "\n")) {
     my $firstchar = substr($line,0,1);

--- a/ls++
+++ b/ls++
@@ -117,7 +117,7 @@ ls();
 
 sub ls {
   my $view = shift // 'perm_size_file';
-  my($perm, $hlink, $user, $group, $size, $seconds, $file, $rel);
+  my($perm, $hlink, $user, $group, $size, $seconds, $file, $rel, $major_num, $minor_num);
   my($userpad, $grouppad, $sizelen);
   my($second, $minute, $hour, $time, $month, $day, $year, %mon2num); #for Mac OS
   my $the_time=time();
@@ -128,18 +128,37 @@ sub ls {
   local $/=undef;
   foreach my $sub (split(/\n\n/, <$ls>)) {
   $sizelen = get_max_size_len($sub);
+  printf("maxsize=%s\n", $sizelen);
+  my $special_file;
   foreach my $line (split(/^/, $sub . "\n")) {
+    my $firstchar = substr($line,0,1);
+    if ($firstchar eq "b" || $firstchar eq "c"){ #special block or character files
+      $special_file = 'true';
+    }
+    else {
+      $special_file = 'false';
+    }
     if ($line =~ /^\n$/) {
       print();
       next;
     }
     # Assume GNU coreutils
     if($^O eq 'linux') {
-      ($perm, $hlink, $user, $group, $size, $seconds, $file) = split(/\s+/, $line, 7)
-        unless $line =~ /^\s/;
-        chop($file);
-
-      ($userpad, $grouppad) = $line =~ m/\d+\s+\S+\s(\s*)\S+(\s*)\s.{$sizelen}\s/;
+      if ($special_file ne "true"){
+        ($perm, $hlink, $user, $group, $size, $seconds, $file) = split(/\s+/, $line, 7)
+          unless $line =~ /^\s/;
+          chop($file);
+          ($userpad, $grouppad) = $line =~ m/\d+\s+\S+\s(\s*)\S+(\s*)\s.{$sizelen}\s/;
+        }
+      else {
+        ($perm, $hlink, $user, $group, $major_num, $minor_num, $seconds, $file) = split(/\s+|,\s*/, $line, 8)
+          unless $line =~ /^\s/;
+          $size = $major_num . ",". $minor_num; #special file don't list their size as regular files
+          chop($file);
+          ($userpad, $grouppad) = $line =~ m/\d+\s+\S+\s(\s*)\S+(\s*)\s.{$sizelen}\s/;
+        #printf("%s,%s,%s;size:%s\n", $major_num, $minor_num, $seconds, $size);
+        }
+      printf("userpad, grouppad, line: |%s_%s_%s", $userpad, $grouppad, $line);
     }
     elsif( ($^O eq 'darwin') or ($^O =~ /.+bsd$/) ) {
         ($perm, $hlink, $user, $group, $size, $month, $day, $time, $year, $file) = split(/\s+/, $line, 10);
@@ -169,7 +188,9 @@ sub ls {
         printf("\n%s:\n", fg($c[9], fg('bold', $1)));
       }
       elsif( $line =~ /^total (.*)/ ) {
-        printf("%s %s\n", fg($c[1], 'total'), ($size = size($1)) =~ s/\s+//gr);
+        #printf("%s %s\n", fg($c[1], 'total'), ($size = size($1)) =~ s/\s+//gr);
+        (undef, $size) = split(/\s+/, $line);
+        printf("%s %s\n", fg($c[1], 'total'), size($size));
       }
       next;
     }
@@ -243,12 +264,20 @@ sub ls {
 
 sub get_max_size_len {
   my($out) = @_;
-  my($perm, $hlink, $user, $group, $size, $max, $cur);
+  my($perm, $hlink, $user, $group, $size, $size2, $max, $cur);
   $max = 0;
   foreach my $line (split(/^/, $out)) {
-    ($perm, $hlink, $user, $group, $size) = split(/\s+/, $line);
+    if ($line =~ /,/){ #special file
+        (undef, undef, undef, undef, $size, $size2) = split(/\s+/, $line);
+        $size = $size . $size2;
+    }
+    else
+    {
+        (undef, undef, undef, undef, $size) = split(/\s+/, $line);
+    }
     $cur = length($size);
     $max = ($max, $cur)[$max < $cur];
+    printf("size, cur, max: %s_%s_%s\n", $size, $cur, $max);
   }
   return $max;
 }
@@ -388,6 +417,9 @@ sub owner {
 
 sub size {
   my ($size) = @_;
+  if ($size =~ /,/){
+        return $size;
+    }
   #FIXME
   if($colors > 16) {
     #$size =~ s/(\S+)(K)/$c[2]$1\e[0m$c[4]$2\e[0m/gi;# and print "AA\n";

--- a/ls++
+++ b/ls++
@@ -25,7 +25,7 @@ if(not _init_config()) {;
 our(@c, @d, %ls_colors, $symlink_delim, $symlink_color);
 
 my $colors = _get_color_support();
-my ($sizelen, $stringlen);
+my ($sizelen, $stringlen, $permlen);
 
 $ENV{DEBUG} and print "$_ x\n" for @c;
 
@@ -128,11 +128,13 @@ sub ls {
 
   local $/=undef;
   foreach my $sub (split(/\n\n/, <$ls>)) {
-  $sizelen = get_max_size_len($sub);
+  ($sizelen, $permlen) = get_max_col_len($sub);
+  printf("sizelen, perm_len: %s,%s\n", $sizelen, $permlen);
   my $special_file;
   foreach my $line (split(/^/, $sub . "\n")) {
     my $firstchar = substr($line,0,1);
-    if ($firstchar eq "b" || $firstchar eq "c"){ #special block or character files
+    if ($firstchar eq "b" || $firstchar eq "c"){
+      # probably special block or character file
       $special_file = 'true';
     }
     else {
@@ -258,20 +260,23 @@ sub ls {
   }
 }
 
-sub get_max_size_len {
+sub get_max_col_len {
   my($out) = @_;
-  my($size, $max, $cur);
-  $max = 0;
+  my($perm, $size, $max_size, $cur_size, $max_perm, $cur_perm);
+  $max_size = 0;
+  $max_perm = 0;
   foreach my $line (split(/^/, $out)) {
-    (undef, undef, undef, undef, $size) = split(/\s+/, $line);
-    $cur = length($size);
+    ($perm, undef, undef, undef, $size) = split(/\s+/, $line);
+    $cur_size = length($size);
+    $cur_perm = length($perm);
     #special files show between 4 and 7 characters + 1 space: 255, 255
     if ($line =~ /\d+,\s+\d+/){
-        $cur += 4;
+        $cur_size += 4;
     }
-    $max = ($max, $cur)[$max < $cur];
+    $max_size = ($max_size, $cur_size)[$max_size < $cur_size];
+    $max_perm = ($max_perm, $cur_perm)[$max_perm < $cur_perm];
   }
-  return $max;
+  return $max_size, $max_perm;
 }
 
 sub add_ls_color {
@@ -383,8 +388,9 @@ sub perm_size_file {
 
 sub perm {
   my ($perm) = @_;
-  if (substr($perm,-1,1) ne "+"){
-    $perm .= " "; # adding an extra space to align with occasional +
+  if (length($perm) < $permlen){
+    # adding an extra space to align with occasional +
+    $perm .= " ";
   }
 
   $perm =~ s/-/$d[1]/g;


### PR DESCRIPTION
Fixes reading size and mtime columns in directories holding special character or block files #50 
Fixes misaligned permission column in case the extra "+" mask bit is set on a file. 
Adds missing --potsf command line argument to README file

Example screenshot: 
![fixed columns in /dev/](http://i.imgur.com/isJWmZc.png)

Shorter arguments work just fine too (wasn't working before this patch):
![ls++ --psf](http://i.imgur.com/dVWCC3n.png)