### PR TITLE
Fix 8 color mode not displaying size columns properly in tmux/screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ls++ \[OPTION\]... \[FILE\]...
 
 ### GNU/Linux
 
-  ![GNU/Linux screenshot](http://i.japh.se/ls--_gh_screenshot.png)
+  ![GNU/Linux screenshot](https://i.imgur.com/wV2HXFz.png)
 
 ### MacOSX / *BSD
 
@@ -32,7 +32,7 @@ Not known parameters will be passed through to **ls**, so to show hidden files,
     --tpf   time, permissions, file
     --tpsf  time, permissions, size, file (default)
     --ptsf  permissions, time, size, file
-    --potsf permissions, owners, time, size, file
+    --potsf permissions, owners, time, size, file (recommended)
 
 # INSTALLATION
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ ls++ \[OPTION\]... \[FILE\]...
 ### GNU/Linux
 
   ![GNU/Linux screenshot](https://i.imgur.com/wV2HXFz.png)
+  ![GNU/Linux screenshot](https://i.imgur.com/ZWMZhe9.png)
 
 ### MacOSX / *BSD
 
@@ -55,6 +56,10 @@ Not known parameters will be passed through to **ls**, so to show hidden files,
     make && sudo 'make install'
 
     cp ls++.conf $HOME/.ls++.conf
+
+# Notes
+
+Under the hood, this script runs `ls` twice in order to compute column sizes properly.
 
 # HISTORY
 

--- a/ls++
+++ b/ls++
@@ -421,19 +421,19 @@ sub size {
     $size = sprintf("%*s", $sizelen, $size);
     return $size;
   }
+  if($sizelen < 4){ # constraining size length between 4 and 8 characters max
+      $stringlen = 4;
+  }
+  elsif($sizelen >= 8){
+      $stringlen = 7;
+  }
+  else
+  {
+      $stringlen = $sizelen;
+  }
   #FIXME
   if($colors > 16) {
     #$size =~ s/(\S+)(K)/$c[2]$1\e[0m$c[4]$2\e[0m/gi;# and print "AA\n";
-    if($sizelen < 4){ # constraining size length between 4 and 8 characters max
-        $stringlen = 4;
-    }
-    elsif($sizelen >= 8){
-        $stringlen = 7;
-    }
-    else
-    {
-        $stringlen = $sizelen;
-    }
     if($size =~ m/^(\S+)(K)/) {
       $size = sprintf("%27s",
         fg($c[7], sprintf("%*g", $stringlen, $1))
@@ -461,6 +461,17 @@ sub size {
       return $size;
   }
 
+  # Special case for tmux / screen, only 8 colors
+  elsif($ENV{TERM} eq 'screen') {
+    return $size
+      if ($size =~ s/(.*)(K)/sprintf("%s%s%s%s", fg($c[2], sprintf("%*g", $stringlen, $1)), fg($c[2], ''), $2, fg($c[16], ''))/e);
+    return sprintf("%*s", $stringlen,  $size)
+      if ($size =~ s/(.*)(M)/sprintf("%s%s%s", fg($c[7], sprintf("%*g", $stringlen, $1)), $2, fg($c[16], ''))/e);
+    return sprintf("%*s", $stringlen, $size)
+      if ($size =~ s/(.*)(G)/sprintf("%s%s%s", fg($c[3], sprintf("%*g", $stringlen, $1)), $2, fg($c[16], ''))/e);
+    return sprintf("%*s", $stringlen, $size)
+      if ($size =~ s/(\d+)/sprintf("%s%s%s", fg($c[14], sprintf("%*d", $stringlen, $1)), fg('bold','B'), fg($c[16], ''))/e);
+  }
   # ANSI
   else {
     return sprintf("% 26s", $size)

--- a/ls++
+++ b/ls++
@@ -461,7 +461,7 @@ sub size {
       return $size;
   }
 
-  # Special case for tmux / screen, only 8 colors
+  # Special case for tmux / screen, only 8 colors, no bold
   elsif($ENV{TERM} eq 'screen') {
     return $size
       if ($size =~ s/(.*)(K)/sprintf("%s%s%s%s", fg($c[2], sprintf("%*g", $stringlen, $1)), fg($c[2], ''), $2, fg($c[16], ''))/e);
@@ -470,7 +470,7 @@ sub size {
     return sprintf("%*s", $stringlen, $size)
       if ($size =~ s/(.*)(G)/sprintf("%s%s%s", fg($c[3], sprintf("%*g", $stringlen, $1)), $2, fg($c[16], ''))/e);
     return sprintf("%*s", $stringlen, $size)
-      if ($size =~ s/(\d+)/sprintf("%s%s%s", fg($c[14], sprintf("%*d", $stringlen, $1)), fg('bold','B'), fg($c[16], ''))/e);
+      if ($size =~ s/(\d+)/sprintf("%s%s%s", fg($c[14], sprintf("%*d", $stringlen, $1)), 'B', fg($c[16], ''))/e);
   }
   # ANSI
   else {


### PR DESCRIPTION
There was a problem when displaying the size column in tmux, the color codes from the ANSI code block don't get properly interpreted like the basic Linux TTY does.
![tmux bug](https://i.imgur.com/dDUBGho.png)

I added a block to handle screen/tmux properly. Note that I have kept the color codes from the ANSI block, except for the bold which doesn't work in tmux. 
![fixed but wrong colors](https://i.imgur.com/5I8Ank1.png)
Notice that the colors are not the same as the regular 256 colors. It can be fixed, but for this pull request I chose to keep it as close to the original as possible. That way, they are more consistent with the ANSI 8 color mode. Can't take a screenshot of the Linux tty though...
Here is a screenshot of the 256 color mode:
![256 color mode](https://i.imgur.com/ZWMZhe9.png)
I also added this screenshot to the README since the original URLs are dead.