### PR TITLE
ls++.conf: fix order of variables

### DIFF
--- a/ls++.conf
+++ b/ls++.conf
@@ -34,39 +34,6 @@ $symlink_color = 1;
 $symlink_attr  = 'bold';
 
 
-# Here you can define your own custom LS_COLORS rules, much more
-# powerful than the regular LS_COLORS that'll only match on an
-# extension.
-#
-# To color (all) directories differently, match a trailing slash
-# like so:
-#
-#   '/$' => 'bold blue8 underline'
-#
-# Available attributes are:
-#  - 0-255  color index
-#  - any valid X color name
-#  - bold, underline, italic...
-#
-# And you can nest them too:
-#
-#   'README.(md|pod)$' => 'bold italic 197 underline',
-#
-# Remember, these rules are powerful! Match a season premiere and have
-# it stand out:
-#
-# '(?i)(s[0-9]{2}-s[0-9]{2}|s([0-9]{1,2})[eEx]01)|([Ss]?([0-9]{1,2}))[Eex]01' => 'underline bold 196',
-
-
-%ls_colors = (
-  '\.un~$'         => 'IGNORE',
-  '\.sw[o-z]$'     => 'IGNORE',
-  'README$'        => 'bold 220 underline',
-  'Makefile$'      => $c[15],
-  '(=:.+)?\..*rc'  => $c[3],
-#  '/$'             => 'blue8',
-);
-
 #< colorschemes
 # extended colors
 if($colorscheme eq '') {
@@ -146,6 +113,40 @@ elsif($colorscheme eq 'trapd00r') {
   $c[16] = 30 ; # directory
 }
 #>
+
+
+# Here you can define your own custom LS_COLORS rules, much more
+# powerful than the regular LS_COLORS that'll only match on an
+# extension.
+#
+# To color (all) directories differently, match a trailing slash
+# like so:
+#
+#   '/$' => 'bold blue8 underline'
+#
+# Available attributes are:
+#  - 0-255  color index
+#  - any valid X color name
+#  - bold, underline, italic...
+#
+# And you can nest them too:
+#
+#   'README.(md|pod)$' => 'bold italic 197 underline',
+#
+# Remember, these rules are powerful! Match a season premiere and have
+# it stand out:
+#
+# '(?i)(s[0-9]{2}-s[0-9]{2}|s([0-9]{1,2})[eEx]01)|([Ss]?([0-9]{1,2}))[Eex]01' => 'underline bold 196',
+
+
+%ls_colors = (
+  '\.un~$'         => 'IGNORE',
+  '\.sw[o-z]$'     => 'IGNORE',
+  'README$'        => 'bold 220 underline',
+  'Makefile$'      => $c[15],
+  '(=:.+)?\..*rc'  => $c[3],
+#  '/$'             => 'blue8',
+);
 
 
 =pod


### PR DESCRIPTION
Fix order of variables in `ls++.conf`.

Fixes #68 