### PR TITLE
MacOSX Ventura 13.5.2 has different column order for `ls` command

### DIFF
--- a/ls++
+++ b/ls++
@@ -175,6 +175,12 @@ sub ls {
     }
     elsif( ($^O eq 'darwin') or ($^O =~ /.+bsd$/) ) {
         ($perm, $hlink, $user, $group, $size, $day, $month, $time, $year, $file) = split(/\s+/, $line, 10);
+
+        # apparntly new MacOSX changed the order of columnns
+        if (!($day =~ /\d+/)) {
+          ($day, $month) = ($month, $day);
+        }
+
         chop($file);
         if( (!$day) ) {
           printf("%s", $line);


### PR DESCRIPTION
Due to the different column order for `ls` command is MacOSX Ventura 13.5.2, the `ls++` stopped working.